### PR TITLE
Changing "echo" to "printf" in the readme when explaining how to generate a new key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Copy the contents of `public/example/` to a new location and edit the `index.htm
 
 ## Changing the default password
 
-1. Generate a new md5sum with your new password `echo "mynewpassword" | md5sum `
+1. Generate a new md5sum with your new password `printf "mynewpassword" | md5sum `
 2. Take the hash and edit `public/extensions/remote/deckjs-remote.js` and change the hash in `key = '...'`


### PR DESCRIPTION
The default key is

```
key = 'eb0a191797624dd3a48fa681d3061212'
```

Under the current linux mint (ubuntu), the proper key is generated using printf but not echo (newline in the string):

```
$ echo "master" | md5sum
c963080767f45828c31f83ca5cd25d36  -
$ printf "master" | md5sum
eb0a191797624dd3a48fa681d3061212  -
```
